### PR TITLE
Replace log with logrus

### DIFF
--- a/bitbucket/client.go
+++ b/bitbucket/client.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 )
 

--- a/bitbucket/resource_branch_restriction.go
+++ b/bitbucket/resource_branch_restriction.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 )
 

--- a/bitbucket/resource_deployment.go
+++ b/bitbucket/resource_deployment.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 )
 

--- a/bitbucket/resource_deployment_variable.go
+++ b/bitbucket/resource_deployment_variable.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"strings"
 	"time"

--- a/bitbucket/resource_hook.go
+++ b/bitbucket/resource_hook.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/bitbucket/resource_repository_variable.go
+++ b/bitbucket/resource_repository_variable.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/vendor/github.com/apparentlymart/go-textseg/textseg/make_tables.go
+++ b/vendor/github.com/apparentlymart/go-textseg/textseg/make_tables.go
@@ -18,7 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"os/exec"

--- a/vendor/github.com/apparentlymart/go-textseg/textseg/make_test_tables.go
+++ b/vendor/github.com/apparentlymart/go-textseg/textseg/make_test_tables.go
@@ -17,7 +17,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"os/exec"

--- a/vendor/github.com/aws/aws-sdk-go/aws/logger.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/logger.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/golang/protobuf/proto/clone.go
+++ b/vendor/github.com/golang/protobuf/proto/clone.go
@@ -36,7 +36,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/golang/protobuf/proto/equal.go
+++ b/vendor/github.com/golang/protobuf/proto/equal.go
@@ -35,7 +35,7 @@ package proto
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/golang/protobuf/proto/lib.go
+++ b/vendor/github.com/golang/protobuf/proto/lib.go
@@ -224,7 +224,7 @@ To create and play with a Test object:
 	package main
 
 	import (
-		"log"
+		log "github.com/sourcegraph-ce/logrus"
 
 		"github.com/golang/protobuf/proto"
 		pb "./example.pb"
@@ -266,7 +266,7 @@ package proto
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/golang/protobuf/proto/properties.go
+++ b/vendor/github.com/golang/protobuf/proto/properties.go
@@ -37,7 +37,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"sort"

--- a/vendor/github.com/golang/protobuf/proto/text.go
+++ b/vendor/github.com/golang/protobuf/proto/text.go
@@ -40,7 +40,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/go-hclog/int.go
+++ b/vendor/github.com/hashicorp/go-hclog/int.go
@@ -6,7 +6,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"runtime"

--- a/vendor/github.com/hashicorp/go-hclog/log.go
+++ b/vendor/github.com/hashicorp/go-hclog/log.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // NewNullLogger instantiates a Logger for which all calls

--- a/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/mux_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/mux_broker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/rpc"
 	"sync"

--- a/vendor/github.com/hashicorp/go-plugin/server.go
+++ b/vendor/github.com/hashicorp/go-plugin/server.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"os"
 	"os/signal"

--- a/vendor/github.com/hashicorp/go-plugin/stream.go
+++ b/vendor/github.com/hashicorp/go-plugin/stream.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func copyStream(name string, dst io.Writer, src io.Reader) {

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -51,7 +51,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 
 func (f *LevelFilter) Write(p []byte) (n int, err error) {
 	// Note in general that io.Writer can receive any byte sequence
-	// to write, but the "log" package always guarantees that we only
+	// to write, but the log "github.com/sourcegraph-ce/logrus" package always guarantees that we only
 	// get a single line. We use that as a slight optimization within
 	// this method, assuming we're dealing with a single, complete line
 	// of log data.

--- a/vendor/github.com/hashicorp/terraform/command/format/plan.go
+++ b/vendor/github.com/hashicorp/terraform/command/format/plan.go
@@ -3,7 +3,7 @@ package format
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform/config/interpolate_funcs.go
+++ b/vendor/github.com/hashicorp/terraform/config/interpolate_funcs.go
@@ -109,7 +109,7 @@ func Funcs() map[string]ast.Function {
 		"jsonencode":   interpolationFuncJSONEncode(),
 		"length":       interpolationFuncLength(),
 		"list":         interpolationFuncList(),
-		"log":          interpolationFuncLog(),
+		log "github.com/sourcegraph-ce/logrus":          interpolationFuncLog(),
 		"lower":        interpolationFuncLower(),
 		"map":          interpolationFuncMap(),
 		"max":          interpolationFuncMax(),

--- a/vendor/github.com/hashicorp/terraform/config/module/storage.go
+++ b/vendor/github.com/hashicorp/terraform/config/module/storage.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 

--- a/vendor/github.com/hashicorp/terraform/config/module/tree.go
+++ b/vendor/github.com/hashicorp/terraform/config/module/tree.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path/filepath"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform/configs/configload/getter.go
+++ b/vendor/github.com/hashicorp/terraform/configs/configload/getter.go
@@ -2,7 +2,7 @@ package configload
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 

--- a/vendor/github.com/hashicorp/terraform/dag/marshal.go
+++ b/vendor/github.com/hashicorp/terraform/dag/marshal.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform/dag/walk.go
+++ b/vendor/github.com/hashicorp/terraform/dag/walk.go
@@ -2,7 +2,7 @@ package dag
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"time"
 

--- a/vendor/github.com/hashicorp/terraform/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform/helper/logging/logging.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"syscall"

--- a/vendor/github.com/hashicorp/terraform/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform/helper/logging/transport.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform/helper/plugin/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform/helper/plugin/grpc_provider.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform/helper/plugin/grpc_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform/helper/plugin/grpc_provisioner.go
@@ -1,7 +1,7 @@
 package plugin
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	proto "github.com/hashicorp/terraform/internal/tfplugin5"

--- a/vendor/github.com/hashicorp/terraform/helper/resource/state.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/state.go
@@ -1,7 +1,7 @@
 package resource
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"reflect"

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing_import_state.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing_import_state.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform/helper/schema/field_reader_config.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/field_reader_config.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform/helper/schema/resource.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/resource.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform/config"

--- a/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform/helper/schema/resource_timeout.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/resource_timeout.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/config"

--- a/vendor/github.com/hashicorp/terraform/httpclient/useragent.go
+++ b/vendor/github.com/hashicorp/terraform/httpclient/useragent.go
@@ -2,7 +2,7 @@ package httpclient
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform/internal/initwd/from_module.go
+++ b/vendor/github.com/hashicorp/terraform/internal/initwd/from_module.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform/internal/earlyconfig"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform/internal/initwd/getter.go
+++ b/vendor/github.com/hashicorp/terraform/internal/initwd/getter.go
@@ -2,7 +2,7 @@ package initwd
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform/internal/initwd/module_install.go
+++ b/vendor/github.com/hashicorp/terraform/internal/initwd/module_install.go
@@ -2,7 +2,7 @@ package initwd
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform/internal/modsdir/manifest.go
+++ b/vendor/github.com/hashicorp/terraform/internal/modsdir/manifest.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 

--- a/vendor/github.com/hashicorp/terraform/lang/eval.go
+++ b/vendor/github.com/hashicorp/terraform/lang/eval.go
@@ -2,7 +2,7 @@ package lang
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/hcl2/ext/dynblock"

--- a/vendor/github.com/hashicorp/terraform/lang/funcs/encoding.go
+++ b/vendor/github.com/hashicorp/terraform/lang/funcs/encoding.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"unicode/utf8"
 

--- a/vendor/github.com/hashicorp/terraform/lang/functions.go
+++ b/vendor/github.com/hashicorp/terraform/lang/functions.go
@@ -75,7 +75,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"keys":             funcs.KeysFunc,
 			"length":           funcs.LengthFunc,
 			"list":             funcs.ListFunc,
-			"log":              funcs.LogFunc,
+			log "github.com/sourcegraph-ce/logrus":              funcs.LogFunc,
 			"lookup":           funcs.LookupFunc,
 			"lower":            stdlib.LowerFunc,
 			"map":              funcs.MapFunc,

--- a/vendor/github.com/hashicorp/terraform/plugin/discovery/find.go
+++ b/vendor/github.com/hashicorp/terraform/plugin/discovery/find.go
@@ -2,7 +2,7 @@ package discovery
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform/plugin/discovery/get.go
+++ b/vendor/github.com/hashicorp/terraform/plugin/discovery/get.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/terraform/plugin/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform/plugin/grpc_provider.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"context"
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform/plugin/grpc_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform/plugin/grpc_provisioner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	plugin "github.com/hashicorp/go-plugin"

--- a/vendor/github.com/hashicorp/terraform/registry/client.go
+++ b/vendor/github.com/hashicorp/terraform/registry/client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"path"

--- a/vendor/github.com/hashicorp/terraform/states/statefile/version1_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform/states/statefile/version1_upgrade.go
@@ -2,7 +2,7 @@ package statefile
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/mitchellh/copystructure"
 )

--- a/vendor/github.com/hashicorp/terraform/states/statefile/version2_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform/states/statefile/version2_upgrade.go
@@ -2,7 +2,7 @@ package statefile
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform/states/sync.go
+++ b/vendor/github.com/hashicorp/terraform/states/sync.go
@@ -1,7 +1,7 @@
 package states
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform/addrs"

--- a/vendor/github.com/hashicorp/terraform/svchost/disco/disco.go
+++ b/vendor/github.com/hashicorp/terraform/svchost/disco/disco.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"mime"
 	"net/http"
 	"net/url"

--- a/vendor/github.com/hashicorp/terraform/svchost/disco/host.go
+++ b/vendor/github.com/hashicorp/terraform/svchost/disco/host.go
@@ -3,7 +3,7 @@ package disco
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/github.com/hashicorp/terraform/terraform/context.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/context.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/context_input.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/context_input.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/hashicorp/hcl2/hcl"

--- a/vendor/github.com/hashicorp/terraform/terraform/diff.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/diff.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/tfdiags"
 )

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_apply.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_apply.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_context_builtin.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_context_builtin.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform/plans"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_count.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_count.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform/addrs"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_count_boundary.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_count_boundary.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_diff.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_diff.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_import_state.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_import_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/providers"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_lang.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_lang.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_output.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_output.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_provider.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_read_data.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_read_data.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_refresh.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_state.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_state_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_state_upgrade.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_validate.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_validate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform/addrs"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_variable.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_variable.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/evaluate.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/evaluate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform/terraform/graph.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/graph.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/tfdiags"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/graph_builder.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/graph_builder.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform/tfdiags"

--- a/vendor/github.com/hashicorp/terraform/terraform/graph_builder_refresh.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/graph_builder_refresh.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/tfdiags"

--- a/vendor/github.com/hashicorp/terraform/terraform/graph_walk_context.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/graph_walk_context.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform/terraform/interpolate.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/interpolate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform/terraform/node_resource_abstract.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/node_resource_abstract.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform/addrs"

--- a/vendor/github.com/hashicorp/terraform/terraform/node_resource_apply.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/node_resource_apply.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/terraform/terraform/node_resource_destroy.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/node_resource_destroy.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/providers"

--- a/vendor/github.com/hashicorp/terraform/terraform/node_resource_plan.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/node_resource_plan.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/dag"
 	"github.com/hashicorp/terraform/tfdiags"

--- a/vendor/github.com/hashicorp/terraform/terraform/node_resource_refresh.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/node_resource_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/providers"

--- a/vendor/github.com/hashicorp/terraform/terraform/schemas.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/schemas.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"

--- a/vendor/github.com/hashicorp/terraform/terraform/state.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/state.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform/terraform/state_upgrade_v2_to_v3.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/state_upgrade_v2_to_v3.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/dag"
 )

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_attach_config_resource.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_attach_config_resource.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_attach_schema.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_attach_schema.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_attach_state.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_attach_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/dag"
 	"github.com/hashicorp/terraform/states"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_config.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_config.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform/addrs"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_destroy_cbd.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_destroy_cbd.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_destroy_edge.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_destroy_edge.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/states"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_diff.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/dag"
 	"github.com/hashicorp/terraform/plans"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_expand.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_expand.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/dag"
 )

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_orphan_count.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_orphan_count.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_orphan_output.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_orphan_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_orphan_resource.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_orphan_resource.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_output.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_provider.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform/addrs"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_provisioner.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_reference.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_reference.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform/configs/configschema"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_removed_modules.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_removed_modules.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/states"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_state.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/states"
 )

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_targets.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_targets.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"strings"

--- a/vendor/github.com/mitchellh/cli/help.go
+++ b/vendor/github.com/mitchellh/cli/help.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 )

--- a/vendor/github.com/mitchellh/go-testing-interface/testing.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing.go
@@ -4,7 +4,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
@@ -9,7 +9,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/posener/complete/log.go
+++ b/vendor/github.com/posener/complete/log.go
@@ -2,7 +2,7 @@ package complete
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/spf13/afero/memmap.go
+++ b/vendor/github.com/spf13/afero/memmap.go
@@ -15,7 +15,7 @@ package afero
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/ulikunitz/xz/example.go
+++ b/vendor/github.com/ulikunitz/xz/example.go
@@ -9,7 +9,7 @@ package main
 import (
 	"bytes"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 
 	"github.com/ulikunitz/xz"

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -33,7 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"net/http"

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	mathrand "math/rand"
 	"net"

--- a/vendor/golang.org/x/net/http2/write.go
+++ b/vendor/golang.org/x/net/http2/write.go
@@ -7,7 +7,7 @@ package http2
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 

--- a/vendor/golang.org/x/net/internal/timeseries/timeseries.go
+++ b/vendor/golang.org/x/net/internal/timeseries/timeseries.go
@@ -7,7 +7,7 @@ package timeseries // import "golang.org/x/net/internal/timeseries"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/golang.org/x/net/trace/events.go
+++ b/vendor/golang.org/x/net/trace/events.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"runtime"
 	"sort"

--- a/vendor/golang.org/x/net/trace/histogram.go
+++ b/vendor/golang.org/x/net/trace/histogram.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"sync"
 

--- a/vendor/golang.org/x/net/trace/trace.go
+++ b/vendor/golang.org/x/net/trace/trace.go
@@ -68,7 +68,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
+++ b/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
@@ -10,7 +10,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"golang.org/x/oauth2"

--- a/vendor/golang.org/x/sys/unix/mkasm_darwin.go
+++ b/vendor/golang.org/x/sys/unix/mkasm_darwin.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 )

--- a/vendor/golang.org/x/sys/unix/mkpost.go
+++ b/vendor/golang.org/x/sys/unix/mkpost.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"go/format"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"regexp"
 )

--- a/vendor/golang.org/x/text/unicode/bidi/core.go
+++ b/vendor/golang.org/x/text/unicode/bidi/core.go
@@ -4,7 +4,7 @@
 
 package bidi
 
-import "log"
+import log "github.com/sourcegraph-ce/logrus"
 
 // This implementation is a port based on the reference implementation found at:
 // https://www.unicode.org/Public/PROGRAMS/BidiReferenceJava/

--- a/vendor/golang.org/x/text/unicode/bidi/gen.go
+++ b/vendor/golang.org/x/text/unicode/bidi/gen.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"flag"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"golang.org/x/text/internal/gen"
 	"golang.org/x/text/internal/triegen"

--- a/vendor/golang.org/x/text/unicode/norm/maketables.go
+++ b/vendor/golang.org/x/text/unicode/norm/maketables.go
@@ -16,7 +16,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strconv"
 	"strings"

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/google.golang.org/appengine/internal/identity_vm.go
+++ b/vendor/google.golang.org/appengine/internal/identity_vm.go
@@ -7,7 +7,7 @@
 package internal
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/google.golang.org/appengine/internal/main_vm.go
+++ b/vendor/google.golang.org/appengine/internal/main_vm.go
@@ -8,7 +8,7 @@ package internal
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/google.golang.org/appengine/internal/net.go
+++ b/vendor/google.golang.org/appengine/internal/net.go
@@ -8,7 +8,7 @@ package internal
 // It is only used for API calls.
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"runtime"
 	"sync"

--- a/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -21,7 +21,7 @@ package grpclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 )


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-bitbucket', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
scripts
.github
vendor
website
.git
bitbucket
go.opencensus.io
cloud.google.com
google.golang.org
golang.org
github.com
exemplar
plugin
stats
internal
tag
trace
ochttp
propagation
b3
view
internal
tagencoding
tracestate
internal
propagation
go
storage
internal
iam
compute
optional
trace
version
metadata
grpc
genproto
appengine
api
keepalive
grpclog
naming
health
stats
binarylog
codes
internal
connectivity
test
status
credentials
resolver
tap
peer
balancer
encoding
metadata
grpc_health_v1
grpc_binarylog_v1
grpcrand
syscall
transport
envconfig
binarylog
backoff
grpcsync
channelz
bufconn
internal
dns
passthrough
base
roundrobin
proto
googleapis
rpc
iam
api
code
status
v1
annotations
datastore
urlfetch
internal
app_identity
datastore
urlfetch
base
log
remote_api
modules
storage
transport
googleapi
option
internal
gensupport
iterator
v1
http
internal
propagation
transport
internal
uritemplates
x
crypto
net
sys
oauth2
text
cast5
openpgp
blowfish
bcrypt
s2k
armor
packet
elgamal
errors
http
idna
internal
context
http2
trace
httpguts
timeseries
ctxhttp
hpack
unix
jwt
internal
google
jws
unicode
secure
transform
bidi
norm
bidirule
ulikunitz
fatih
googleapis
zclconf
apparentlymart
golang
satori
oklog
jmespath
google
hashicorp
posener
blang
spf13
mitchellh
davecgh
aws
vmihailenco
mattn
armon
bgentry
agext
xz
lzma
internal
hash
xlog
color
gax-go
v2
go-cty-yaml
go-cty
cty
set
json
msgpack
function
convert
gocty
stdlib
go-textseg
go-cidr
textseg
cidr
protobuf
proto
ptypes
protoc-gen-go
any
duration
timestamp
descriptor
go.uuid
run
go-jmespath
go-cmp
cmp
internal
diff
flags
value
function
go-plugin
go-getter
yamux
errwrap
go-uuid
go-version
hcl2
go-multierror
go-cleanhttp
hil
terraform-config-inspect
terraform
hcl
go-safetemp
logutils
go-hclog
internal
plugin
helper
url
hcldec
ext
gohcl
hcled
hclwrite
hcl
hclparse
typeexpr
dynblock
json
hclsyntax
scanner
ast
parser
tfconfig
command
httpclient
tfdiags
providers
configs
provisioners
dag
moduledeps
plugin
config
internal
flatmap
addrs
terraform
states
helper
lang
registry
plans
svchost
version
format
configload
configschema
discovery
convert
module
hcl2shim
earlyconfig
initwd
tfplugin5
modsdir
statefile
structure
plugin
schema
config
hashcode
resource
logging
hilmapstructure
validation
didyoumean
funcs
blocktoattr
response
regsrc
objchange
disco
auth
json
hcl
token
scanner
parser
token
scanner
ast
strconv
parser
complete
cmd
match
install
semver
afero
mem
go-homedir
cli
reflectwalk
go-testing-interface
copystructure
mapstructure
go-wordwrap
hashstructure
colorstring
go-spew
spew
aws-sdk-go
service
internal
private
aws
sts
s3
sdkio
ini
sdkrand
shareddefaults
s3err
sdkuri
protocol
eventstream
rest
restxml
query
xml
eventstreamapi
queryutil
xmlutil
ec2metadata
signer
csm
defaults
session
endpoints
request
awserr
corehandlers
awsutil
credentials
client
v4
endpointcreds
ec2rolecreds
processcreds
stscreds
metadata
msgpack
codes
go-colorable
go-isatty
go-radix
go-netrc
speakeasy
netrc
levenshtein
docs
r
d
objects
info
branches
logs
refs
hooks
97
1b
31
08
94
8d
65
20
99
9f
24
4e
eb
6e
18
b6
e2
78
e6
66
b0
49
fe
01
bd
57
89
5a
c5
1e
e4
f5
d0
1c
44
95
72
dc
12
b7
ee
11
c8
22
1f
53
7a
47
5c
7c
07
fa
59
87
81
9e
75
52
8e
d6
96
ba
e3
29
02
f2
ac
3f
71
4a
ec
10
0e
e7
69
42
a9
9c
a3
6c
db
ea
ff
bf
dd
76
43
3e
34
60
1d
c9
4c
05
ca
26
06
a4
21
d2
85
19
fd
82
9b
a0
c2
f3
fb
b8
b4
cb
0b
c1
a6
0f
74
93
61
5b
51
cf
d1
c7
de
2a
f6
e9
pack
f7
ef
9a
8b
e8
da
d7
b3
ce
79
3a
b5
f1
ae
e0
be
28
a2
info
f8
80
e5
ed
a7
3c
9d
1a
15
a5
56
7d
c6
2b
fc
ad
09
2e
d4
4b
50
98
73
6d
27
f0
3b
70
7e
bc
7f
46
88
0c
c0
af
d5
a8
5e
35
16
b1
40
67
aa
ab
8c
3d
41
e1
b9
6b
23
84
00
37
83
4f
d3
54
0d
33
2f
8f
d9
39
36
55
63
17
77
c4
92
68
f9
c3
04
38
2c
8a
64
b2
7b
48
32
cd
91
6a
14
5d
bb
2d
cc
5f
58
45
f4
03
a1
25
6f
86
62
df
4d
0a
13
30
90
d8
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)